### PR TITLE
Using FORMAT_TEXT_MAP for injection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jcw (0.2.1)
+    jcw (0.2.2)
       activesupport (>= 5.0)
       gruf (~> 2.10)
       httprb-opentracing (~> 0.4.0)

--- a/lib/jcw/http_tracer.rb
+++ b/lib/jcw/http_tracer.rb
@@ -31,7 +31,7 @@ module JCW
 
               tracer.start_active_span("http.request", tags: tags) do |scope|
                 request.headers.merge!(options.headers)
-                OpenTracing.inject(scope.span.context, OpenTracing::FORMAT_RACK,
+                OpenTracing.inject(scope.span.context, OpenTracing::FORMAT_TEXT_MAP,
                                    request.headers)
 
                 res = perform_without_tracing(request, options)

--- a/lib/jcw/version.rb
+++ b/lib/jcw/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JCW
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Use `FORMAT_TEXT_MAP` instead of `FORMAT_RACK` for tracing between not ruby projects.