### PR TITLE
Monotonic duration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jcw (0.5.1)
+    jcw (0.5.2)
       activesupport (>= 5.0)
       httprb-opentracing (~> 0.4.0)
       jaeger-client (~> 1.3.0)
@@ -47,9 +47,9 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    google-protobuf (3.21.3)
-    google-protobuf (3.21.3-x86_64-darwin)
-    google-protobuf (3.21.3-x86_64-linux)
+    google-protobuf (3.21.4)
+    google-protobuf (3.21.4-x86_64-darwin)
+    google-protobuf (3.21.4-x86_64-linux)
     googleapis-common-protos-types (1.3.2)
       google-protobuf (~> 3.14)
     grpc (1.48.0)

--- a/lib/jcw/subscriber.rb
+++ b/lib/jcw/subscriber.rb
@@ -7,7 +7,7 @@ module JCW
     IGNORED_PAYLOAD_KEYS = %i[request response headers exception exception_object].freeze
 
     def subscribe_to_event!(event)
-      ActiveSupport::Notifications.subscribe(event) do |name, start, finish, _uid, payload|
+      ActiveSupport::Notifications.monotonic_subscribe(event) do |name, start, finish, _uid, payload|
         add(name, payload, finish - start)
       end
     end

--- a/lib/jcw/subscriber.rb
+++ b/lib/jcw/subscriber.rb
@@ -7,7 +7,7 @@ module JCW
     IGNORED_PAYLOAD_KEYS = %i[request response headers exception exception_object].freeze
 
     def subscribe_to_event!(event)
-      ActiveSupport::Notifications.monotonic_subscribe(event) do |name, start, finish, _uid, payload|
+      ActiveSupport::Notifications.monotonic_subscribe(event) do |name, start, finish, _id, payload|
         add(name, payload, finish - start)
       end
     end

--- a/lib/jcw/version.rb
+++ b/lib/jcw/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JCW
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/jcw_spec.rb
+++ b/spec/jcw_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe JCW::Wrapper do
     end
 
     specify "set subscribers" do
-      expect(ActiveSupport::Notifications).to receive(:subscribe).with(/.*/)
+      expect(ActiveSupport::Notifications).to receive(:monotonic_subscribe).with(/.*/)
       set_jaeger
     end
 
@@ -59,7 +59,7 @@ RSpec.describe JCW::Wrapper do
       let(:subscribe_to) { [] }
 
       specify "subscribers not set" do
-        expect(ActiveSupport::Notifications).not_to receive(:subscribe).with(/.*/)
+        expect(ActiveSupport::Notifications).not_to receive(:monotonic_subscribe).with(/.*/)
         set_jaeger
       end
     end


### PR DESCRIPTION
Made duration more accurate using `monotonic_subscribe` of `ActiveSupport::Notifications`